### PR TITLE
Develop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }} \
             --delete \
             --exclude "*" --include "*.html" --include "index.html" \
-            --cache-control "max-age=60,public"
+            --cache-control "max-age=86400,public"
 
       - name: Upload sitemaps (XML) and robots (ensure content-type)
         shell: bash


### PR DESCRIPTION
This pull request contains a small but important configuration update to the deployment workflow. The cache duration for HTML files uploaded to S3 has been increased from 1 minute to 24 hours, which should improve performance by reducing unnecessary reloads.

* Increased the S3 `cache-control` max-age for HTML files from 60 seconds to 86400 seconds (24 hours) in `.github/workflows/deploy.yml`.